### PR TITLE
Tests: Add Code Coverage Report and Jest Configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,13 @@ typings/
 
 # Electron-Forge
 out/
+
+# Custom Git Ignore for Electrnro App
+app/dist/renderer.prod.js
+app/dist/renderer.prod.js.LICENSE
+app/dist/style.css
+app/dist/style.css.d.ts
+app/dist/style.css.map
+app/main.prod.js
+app/main.prod.js.LICENSE
+dll/renderer.dev.dll.js

--- a/package.json
+++ b/package.json
@@ -158,7 +158,8 @@
     ],
     "setupFiles": [
       "./internals/scripts/CheckBuildsExist.js"
-    ]
+    ],
+    "collectCoverageFrom": ["**/src/**/*.js"]
   },
   "devDependencies": {
     "@babel/core": "^7.9.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "start": "cross-env NODE_ENV=production electron ./app/main.prod.js",
     "start-main-dev": "cross-env START_HOT=1 NODE_ENV=development electron -r ./internals/scripts/BabelRegister ./app/main.dev.ts",
     "start-renderer-dev": "cross-env NODE_ENV=development webpack-dev-server --config configs/webpack.config.renderer.dev.babel.js",
-    "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 jest",
+    "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 jest --coverage",
     "test-all": "yarn lint && yarn ts && yarn build && yarn test && yarn build-e2e && yarn test-e2e",
     "test-e2e": "node -r @babel/register ./internals/scripts/CheckBuildsExist.js && cross-env NODE_ENV=test testcafe electron:./app ./test/e2e/HomePage.e2e.ts",
     "test-e2e-live": "node -r @babel/register ./internals/scripts/CheckBuildsExist.js && cross-env NODE_ENV=test testcafe --live electron:./app ./test/e2e/HomePage.e2e.ts",


### PR DESCRIPTION
## Description:
- Modify package.json to enable Jest code coverage report. This enables viewing of function, statement, branch, and line coverage for currently existing files.
- Modify package.json to collect coverage report only from the src folder, the origin of where the components of the app will render
## Changes I Made:
- Modified root directory package.json, specifically the scripts "test" to include the syntax "--coverage" so that it will generate a code coverage report
- Modified root directory package.json, configuring jest to collect coverage from src specifically
## How to Test:
- In the terminal, type in 'yarn test' to initiate code coverage report output in the terminal. Additionally, reports can also be viewed in coverage/lcov-report/index.html in the browser